### PR TITLE
Add draggable dashboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,31 +86,35 @@ The application is organised into several modules:
 
 2. **Navigation**
    - The sidebar provides quick access to all modules. Collapse or expand it using the hamburger icon.
-   - The dashboard shows alerts, crew movements and KPI summaries.
+ - The dashboard shows alerts, crew movements and KPI summaries.
 
-3. **Crew Rotation**
+3. **Customising the Dashboard**
+   - Drag and resize the widgets on the dashboard to create your preferred layout.
+   - Your layout is saved locally and restored on the next visit.
+
+4. **Crew Rotation**
    - Forecast and plan rotations, review candidate matches and approve lineups.
    - Mobilisation and handover tabs help track joining and relief processes.
    - Analytics summarises performance and rotation statistics.
 
-4. **Crew Lists**
+5. **Crew Lists**
    - "Onboard" and "Vacation" sections display crew tables with search and filter tools.
    - Click a crew member to view contract previews and compliance information.
 
-5. **Vessel Management**
+6. **Vessel Management**
    - "All Vessels" lists each vessel. Select one to view or edit its particulars and see the current crew list.
 
-6. **Crew Change**
+7. **Crew Change**
    - Track upcoming, active and past crew changes. Use the "Add New Crew Change" button to schedule a change.
    - Print itinerary details from the active list when needed.
 
-7. **Seafarer Applications**
+8. **Seafarer Applications**
    - The application form captures personal info, experience and training records. Submit to generate an application ID.
 
-8. **P&I Module**
+9. **P&I Module**
    - Manage Protection & Indemnity cases. Editing a case requires authentication (use `admin` / `adminedit` for the demo).
 
-9. **Database Migration & Export**
+10. **Database Migration & Export**
    - Use the export tools in the sidebar to download templates or generate PDF/QR reports.
    - The upload option allows importing crew data from CSV/XLSX files (mocked in this demo).
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
     "react-resizable-panels": "^2.1.3",
+    "react-grid-layout": "^1.4.4",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",
     "sonner": "^1.5.0",

--- a/src/components/DashboardOverview.tsx
+++ b/src/components/DashboardOverview.tsx
@@ -1,11 +1,23 @@
 
-import { useState } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Bell } from "lucide-react";
+import { WidthProvider, Responsive, Layout } from "react-grid-layout";
+import { useDashboardLayout } from "@/hooks/useDashboardLayout";
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
+
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+const defaultLayout: Layout[] = [
+  { i: "alerts", x: 0, y: 0, w: 6, h: 3 },
+  { i: "crew", x: 0, y: 3, w: 6, h: 5 },
+  { i: "charts", x: 6, y: 0, w: 6, h: 8 },
+];
 
 const DashboardOverview = () => {
+  const { layout, setLayout } = useDashboardLayout(defaultLayout);
   const alerts = [
     { type: "Critical", count: 12, message: "expiring documents this month", color: "destructive" },
     { type: "Warning", count: 5, message: "crew due for medical renewal", color: "secondary" },
@@ -27,35 +39,42 @@ const DashboardOverview = () => {
   ];
 
   return (
-    <div className="space-y-4">
-      {/* Alerts & Warnings Section */}
-      <Card>
-        <CardHeader className="flex flex-row items-center gap-2 pb-3">
-          <Bell className="h-4 w-4" />
-          <CardTitle className="text-lg">Alerts & Warnings</CardTitle>
-        </CardHeader>
-        <CardContent className="pt-0">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            {alerts.map((alert, index) => (
-              <div key={index} className="flex items-center justify-between p-2 rounded-lg border">
-                <div className="flex items-center gap-2">
-                  <Badge variant={alert.color as any} className="text-xs">
-                    {alert.type}
-                  </Badge>
-                  <span className="text-sm text-muted-foreground">
-                    <strong>{alert.count}</strong> {alert.message}
-                  </span>
-                </div>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        {/* Crew Movement Overview */}
+    <ResponsiveGridLayout
+      className="layout"
+      layouts={{ lg: layout }}
+      cols={{ lg: 12 }}
+      rowHeight={30}
+      onLayoutChange={(_l, all) => setLayout(all.lg)}
+      draggableHandle=".draggable-handle"
+    >
+      <div key="alerts">
         <Card>
-          <CardHeader className="pb-3">
+          <CardHeader className="flex flex-row items-center gap-2 pb-3 draggable-handle">
+            <Bell className="h-4 w-4" />
+            <CardTitle className="text-lg">Alerts & Warnings</CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {alerts.map((alert, index) => (
+                <div key={index} className="flex items-center justify-between p-2 rounded-lg border">
+                  <div className="flex items-center gap-2">
+                    <Badge variant={alert.color as any} className="text-xs">
+                      {alert.type}
+                    </Badge>
+                    <span className="text-sm text-muted-foreground">
+                      <strong>{alert.count}</strong> {alert.message}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div key="crew">
+        <Card>
+          <CardHeader className="pb-3 draggable-handle">
             <CardTitle className="text-lg">📊 Crew Movement Overview</CardTitle>
           </CardHeader>
           <CardContent className="pt-0">
@@ -84,10 +103,11 @@ const DashboardOverview = () => {
             </div>
           </CardContent>
         </Card>
+      </div>
 
-        {/* Summary Charts */}
+      <div key="charts">
         <Card>
-          <CardHeader className="pb-3">
+          <CardHeader className="pb-3 draggable-handle">
             <CardTitle className="text-lg">📈 Summary Charts</CardTitle>
           </CardHeader>
           <CardContent className="pt-0">
@@ -105,7 +125,7 @@ const DashboardOverview = () => {
           </CardContent>
         </Card>
       </div>
-    </div>
+    </ResponsiveGridLayout>
   );
 };
 

--- a/src/hooks/useDashboardLayout.ts
+++ b/src/hooks/useDashboardLayout.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { Layout } from "react-grid-layout";
+
+const STORAGE_KEY = "dashboardLayout";
+
+export function useDashboardLayout(defaultLayout: Layout[]) {
+  const [layout, setLayout] = useState<Layout[]>(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        try {
+          return JSON.parse(stored) as Layout[];
+        } catch {
+          /* ignore invalid json */
+        }
+      }
+    }
+    return defaultLayout;
+  });
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(layout));
+    }
+  }, [layout]);
+
+  return { layout, setLayout };
+}


### PR DESCRIPTION
## Summary
- make dashboard cards draggable/resizable using `react-grid-layout`
- persist layout to localStorage with new `useDashboardLayout` hook
- document dashboard customisation in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d2a20c4083259774c60bbac48f92